### PR TITLE
Changed how  `SherpaFloat` is imported.

### DIFF
--- a/fantasy_agn/models.py
+++ b/fantasy_agn/models.py
@@ -8,7 +8,8 @@ import pandas as pd
 from astropy.modeling.models import BlackBody
 from sherpa.models import model
 from sherpa.models.parameter import Parameter, tinyval
-from sherpa.utils import SherpaFloat, sao_fcmp
+from sherpa.utils.numeric_types import SherpaFloat
+from sherpa.utils import sao_fcmp
 
 __all__ = (
     "create_input_folder",


### PR DESCRIPTION
I was having trouble runnung the tutorial files for fantasy. The error was in `models.py`, where an error saying it wasn't able to import `SherpaFloat` from `sherpa.utils` appeared.

Sherpa (4.16.0) documentation shows that `SherpaFloat` should now be imported like `from sherpa.utils.numeric_types import SherpaFloat` (for example, looking at [this](https://sherpa.readthedocs.io/en/4.16.0/_modules/sherpa/astro/optical.html) module).